### PR TITLE
Updated to angular2-rc.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   },
   "homepage": "https://github.com/gdi2290/angular2-hmr#readme",
   "devDependencies": {
-    "angular2": "^2.0.0-beta.16",
-    "rxjs": "^5.0.0-beta.2",
+    "@angular/core": "^2.0.0-rc.0",
+    "rxjs": "5.0.0-beta.6",
     "typescript": "^1.8.9",
     "typings": "^0.7.9"
   },

--- a/src/hmr-store.ts
+++ b/src/hmr-store.ts
@@ -1,4 +1,4 @@
-import {OpaqueToken} from 'angular2/core';
+import {OpaqueToken} from '@angular/core';
 
 export const HMR_STATE = new OpaqueToken('hmrState');
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import {Provider} from 'angular2/core';
+import {Provider} from '@angular/core';
 import {HMR_STATE, HmrStore} from './hmr-store';
 
 export * from './webpack-hmr';


### PR DESCRIPTION
Since yesterday, **angular2-rc.0** is out. The whole angular2-package moved to their own name scope _@angular/_ which is a breaking change. 

So I changed the angular- and rxjs-Versions in the package.json as well as the import statements to reflect the new path.

Since there are no tests yet I tested it manually & locally on one of my projects and it was working perfectly.